### PR TITLE
Port to Python 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python library for TSL2561
 
 Requirements
 ------------
-  - python 2.7.x
+  - python 3.x
   - Adafruit GPIO library (https://github.com/adafruit/Adafruit_Python_GPIO)
   - Adafruit PureIO library (https://github.com/adafruit/Adafruit_Python_PureIO)
 
@@ -19,7 +19,7 @@ Example
 
   if __name__ == "__main__":
     tsl = TSL2561(debug=1)
-    print tsl.lux()
+    print(tsl.lux())
   ```
 
 License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python library for TSL2561
 
 Requirements
 ------------
-  - python 3.x
+  - Python 2.7 or Python 3.x
   - Adafruit GPIO library (https://github.com/adafruit/Adafruit_Python_GPIO)
   - Adafruit PureIO library (https://github.com/adafruit/Adafruit_Python_PureIO)
 

--- a/tsl2561/tsl2561.py
+++ b/tsl2561/tsl2561.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 '''Driver for the TSL2561 digital luminosity (light) sensors.
 
 Pick one up at http://www.adafruit.com/products/439
@@ -18,11 +18,12 @@ from Adafruit_GPIO import I2C
 from tsl2561.constants import *  # pylint: disable=unused-wildcard-import
 
 __author__ = 'Georges Toth <georges@trypill.org>'
-__credits__ = ['K.Townsend (Adafruit Industries)', 'Yongwen Zhuang (zYeoman)', 'miko (mikostn)']
+__credits__ = ['K.Townsend (Adafruit Industries)', 'Yongwen Zhuang (zYeoman)', 'miko (mikostn)', 'Simon Gansen (theFork)']
 __license__ = 'BSD'
-__version__ = 'v2.2'
+__version__ = 'v3.0'
 
 '''HISTORY
+v3.0 - Port to Python 3.x
 v2.2 - Merge PR #4 regarding wrong use of integration time
 v2.1 - Minor adaptations required by latest Adafruit pyton libraries
 v2.0 - Rewrote driver for Adafruit_Sensor and Auto-Gain support, and
@@ -36,10 +37,14 @@ class TSL2561(object):
     def __init__(self, address=None, busnum=None,
                  integration_time=TSL2561_INTEGRATIONTIME_402MS,
                  gain=TSL2561_GAIN_1X, autogain=False, debug=False):
+
+        # Set default address and bus number if not given
         if address is not None:
             self.address = address
         else:
             self.address = TSL2561_ADDR_FLOAT
+        if busnum == None:
+            self.busnum = 1
 
         self.i2c = I2C.get_i2c_device(self.address, busnum=busnum)
 
@@ -251,7 +256,7 @@ class TSL2561(object):
             ratio1 = (channel1 << (TSL2561_LUX_RATIOSCALE + 1)) / channel0
 
         # round the ratio value
-        ratio = (ratio1 + 1) >> 1
+        ratio = (int(ratio1) + 1) >> 1
 
         b = 0
         m = 0
@@ -296,14 +301,14 @@ class TSL2561(object):
         # Signal I2C had no errors
         return lux
 
+
     def lux(self):
         '''Read sensor data, convert it to LUX and return it'''
         broadband, ir = self._get_luminosity()
-
         return self._calculate_lux(broadband, ir)
 
 
 if __name__ == "__main__":
     tsl = TSL2561(debug=True)
 
-    print tsl.lux()
+    print(tsl.lux())

--- a/tsl2561/tsl2561.py
+++ b/tsl2561/tsl2561.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 '''Driver for the TSL2561 digital luminosity (light) sensors.
 
 Pick one up at http://www.adafruit.com/products/439


### PR DESCRIPTION
I think by now, most people are using Python3.x. For this driver, only a few changes were necessary.